### PR TITLE
「お気に入り」機能の実装

### DIFF
--- a/app/assets/javascripts/favorites.coffee
+++ b/app/assets/javascripts/favorites.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/favorites.scss
+++ b/app/assets/stylesheets/favorites.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the favorites controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,9 @@
+class FavoritesController < ApplicationController
+  def create
+
+  end
+
+  def destroy
+
+  end
+end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,7 +1,6 @@
 class FavoritesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_item
-  before_action :check_make_favorite
 
   def create
     @item.add_fav(current_user)
@@ -17,10 +16,5 @@ class FavoritesController < ApplicationController
   private
     def set_item
       @item = Item.find(params[:item_id])
-    end
-
-    # Check if the owner of the item.
-    def check_make_favorite
-      raise PermissionDeniedError, "このアイテムはお気に入りにできません" if @item.editable_by?(current_user)
     end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,5 +1,7 @@
 class FavoritesController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_item
+  before_action :check_make_favorite
 
   def create
     @item.add_fav(current_user)
@@ -15,5 +17,10 @@ class FavoritesController < ApplicationController
   private
     def set_item
       @item = Item.find(params[:item_id])
+    end
+
+    # Check if the owner of the item.
+    def check_make_favorite
+      raise PermissionDeniedError, "このアイテムはお気に入りにできません" if @item.editable_by?(current_user)
     end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -9,6 +9,7 @@ class FavoritesController < ApplicationController
 
   def destroy
     favorite = Favorite.find(params[:id])
+    raise PermissionDeniedError, "アクセス権がありません" unless favorite.user == current_user
     favorite.destroy
     redirect_to @item, notice: 'お気に入りから削除されました'
   end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,9 +1,19 @@
 class FavoritesController < ApplicationController
-  def create
+  before_action :set_item
 
+  def create
+    @item.add_fav(current_user)
+    redirect_to @item, notice: 'お気に入りに登録されました'
   end
 
   def destroy
-
+    favorite = Favorite.find(params[:id])
+    favorite.destroy
+    redirect_to @item, notice: 'お気に入りから削除されました'
   end
+
+  private
+    def set_item
+      @item = Item.find(params[:item_id])
+    end
 end

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -1,0 +1,2 @@
+module FavoritesHelper
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -31,11 +31,11 @@ class Item < ActiveRecord::Base
 
   #Find user's favorites
   def find_fav(user)
-    user.favorites.find_by(item_id: self.id)
+    @favorite = user.favorites.find_by(item_id: self.id)
   end
 
   #Is it a user's favorite?
   def favorited_by?(user)
-    user.favorites.find_by(item_id: self.id).present?
+    self.find_fav(user).present?
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -28,4 +28,9 @@ class Item < ActiveRecord::Base
     raise StandardError, "このアイテムのオーナー様は、アイテムをお気に入り登録できません" if self.user_id == user.id
     user.favorites.create!(item_id: self.id)
   end
+
+  #Find user's favorites
+  def find_fav(user)
+    user.favorites.find_by(item_id: self.id)
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -33,4 +33,9 @@ class Item < ActiveRecord::Base
   def find_fav(user)
     user.favorites.find_by(item_id: self.id)
   end
+
+  #Is it a user's favorite?
+  def favorited_by?(user)
+    user.favorites.find_by(item_id: self.id).present?
+  end
 end

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,0 +1,33 @@
+<table>
+  <thead>
+    <tr>
+      <th>出品者</th>
+      <th>商品名</th>
+      <th>商品イメージ</th>
+      <th>商品について</th>
+      <th>目標金額</th>
+      <th>サポーター</th>
+      <th>終了日</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% items.each do |item| %>
+      <tr>
+        <td><%= item.user.name %></td>
+        <td><%= item.name %></td>
+        <td><%= item.image %></td>
+        <td><%= item.description %></td>
+        <td><%= number_to_currency(item.target_price, :locale => 'jp') %></td>
+        <td><%= item.supports.count %>人</td>
+        <td><%= item.limited_at.strftime('%Y年%m月%d日') %></td>
+        <td><%= link_to 'Show', item %></td>
+        <% if user_signed_in? && item.editable_by?(current_user) %>
+          <td><%= link_to 'Edit', edit_item_path(item) %></td>
+          <td><%= link_to 'Destroy', item, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,38 +1,6 @@
 <h1>アイテム一覧</h1>
 
-<table>
-  <thead>
-    <tr>
-      <th>出品者</th>
-      <th>商品名</th>
-      <th>商品イメージ</th>
-      <th>商品について</th>
-      <th>目標金額</th>
-      <th>サポーター</th>
-      <th>終了日</th>
-      <th colspan="3"></th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @items.each do |item| %>
-      <tr>
-        <td><%= item.user.name %></td>
-        <td><%= item.name %></td>
-        <td><%= item.image %></td>
-        <td><%= item.description %></td>
-        <td><%= number_to_currency(item.target_price, :locale => 'jp') %></td>
-        <td><%= item.supports.count %>人</td>
-        <td><%= item.limited_at.strftime('%Y年%m月%d日') %></td>
-        <td><%= link_to 'Show', item %></td>
-        <% if user_signed_in? && item.editable_by?(current_user) %>
-          <td><%= link_to 'Edit', edit_item_path(item) %></td>
-          <td><%= link_to 'Destroy', item, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-        <% end %>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= render partial: "item", :locals => {items: @items} %>
 
 <br>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -37,15 +37,16 @@
 
 <p><%= link_to 'このコースに申し込む', buy_path(@item), method: :post %></p>
 
-<% if user_signed_in? && !@item.editable_by?(current_user) %> <!--他人の出品アイテム画面であればお気に入りリンクを表示する-->
-  <% if @item.find_fav(current_user) %>
+<% if user_signed_in? && !@item.editable_by?(current_user) %>
+  <% if @item.favorited_by?(current_user) %>
     <p><button><%= link_to 'お気に入りから削除', favorite_path(@item.find_fav(current_user), item_id: @item.id), method: :delete %></button></p>
   <% else %>
     <p><button><%= link_to 'お気に入りに登録', user_favorites_path(current_user.id, item_id: @item.id), method: :post %></button></p>
   <% end %>
 <% end %>
 
- <% if user_signed_in? && @item.editable_by?(current_user) %>
-  <%= link_to 'Edit', edit_item_path(@item) %> |
- <% end %>
+<% unless user_signed_in? %>
+  <p><button><%= link_to 'お気に入りに登録', user_favorites_path(0, item_id: @item.id), method: :post %></button></p>
+<% end %>
+
  <%= link_to 'Back', root_path %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -37,6 +37,14 @@
 
 <p><%= link_to 'このコースに申し込む', buy_path(@item), method: :post %></p>
 
+<% if user_signed_in? && !@item.editable_by?(current_user) %> <!--他人の出品アイテム画面であればお気に入りリンクを表示する-->
+  <% if @item.find_fav(current_user) %>
+    <p><button><%= link_to 'お気に入りから削除', favorite_path(@item.find_fav(current_user), item_id: @item.id), method: :delete %></button></p>
+  <% else %>
+    <p><button><%= link_to 'お気に入りに登録', user_favorites_path(current_user.id, item_id: @item.id), method: :post %></button></p>
+  <% end %>
+<% end %>
+
  <% if user_signed_in? && @item.editable_by?(current_user) %>
   <%= link_to 'Edit', edit_item_path(@item) %> |
  <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
   resources :items,only:[:new, :create, :show, :update, :edit, :destroy]
   post 'supports/:item_id' => 'supports#buy', as: 'buy'
   devise_for :users
+
+  resources :users, shallow:true do
+    resources :favorites,only:[:create, :destroy]
+  end  
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :favorite do
-    user
-    item
+    user_id
+    item_id
   end
 end

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :favorite do
-    user_id
-    item_id
+    user
+    item
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -110,12 +110,12 @@ describe 'favorited_by?' do
   let(:other) { FactoryGirl.create(:user) }
 
   #userがitemをお気に入りしているかどうか真偽値で返す
-  it "itemがお気に入りされているので" do
+  it "itemがお気に入りされているので、真" do
     favorite = other.favorites.create(item_id: item.id)
     expect(item.favorited_by?(other)).to eq true
   end
 
-  it "itemがお気に入りされていないので偽" do
+  it "itemがお気に入りされていないので、偽" do
     expect(item.favorited_by?(other)).to eq false
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -89,3 +89,18 @@ describe 'add_fav' do
     expect{ item.add_fav(item.user) }.to raise_error(StandardError)
   end
 end
+
+describe 'find_fav' do
+  let(:item) { FactoryGirl.create(:item) }
+  let(:other) { FactoryGirl.create(:user) }
+
+  # userのお気に入りのデータを返す
+  it "favoriteが存在すれば有効な値が返される" do
+    favorite = other.favorites.create(item_id: item.id)
+    expect(item.find_fav(other).id).to eq favorite.id
+  end
+
+  it "favoriteが存在しなければnilが返される" do
+    expect(item.find_fav(other)).to eq nil
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -104,3 +104,18 @@ describe 'find_fav' do
     expect(item.find_fav(other)).to eq nil
   end
 end
+
+describe 'favorited_by?' do
+  let(:item) { FactoryGirl.create(:item) }
+  let(:other) { FactoryGirl.create(:user) }
+
+  #userがitemをお気に入りしているかどうか真偽値で返す
+  it "itemがお気に入りされているので" do
+    favorite = other.favorites.create(item_id: item.id)
+    expect(item.favorited_by?(other)).to eq true
+  end
+
+  it "itemがお気に入りされていないので偽" do
+    expect(item.favorited_by?(other)).to eq false
+  end
+end


### PR DESCRIPTION
closed #17 

- [x]  favorites#createアクション、favorites#destroyアクションへのルーティングを設定
- [x]  favoritesコントローラ作成
- [x]  アイテム一覧画面をパーシャル化
------------------------------------------------------------------------------------------
- [x] favoritesコントローラの中身を書く
- [x] 「ユーザのお気に入りを検索」する、モデルのメソッド Item#find_fav(user) を作成
- [x] Item#find_fav(user) のテストを書く
- [x] 「ユーザにお気に入りされてる？」かどうか調べる、モデルのメソッドItem#favorited_by?(user)
 を作成
- [x] Item#favorited_by?(user)のテストを書く
- [x] アイテム詳細画面にお気に入りボタンを作成する
- [x] アイテム詳細画面にお気に入り取り消しボタンを作成する
- [x] アイテム詳細画面のお気に入りボタンとお気に入り取り消しボタンが状況に応じて一方だけが表示されるようにする


