### PR TITLE
お気に入り機能 複合ユニーク制約追加

### DIFF
--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,4 +1,7 @@
 class Favorite < ActiveRecord::Base
+  #relation
   belongs_to :user
-  belongs_to :item  
+  belongs_to :item
+  #validation
+  validates :user_id, uniqueness: { scope: [:item_id] }
 end

--- a/db/migrate/20170104115438_add_index_to_favorites.rb
+++ b/db/migrate/20170104115438_add_index_to_favorites.rb
@@ -1,0 +1,5 @@
+class AddIndexToFavorites < ActiveRecord::Migration
+  def change
+    add_index :favorites, [:user_id, :item_id], :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161225062736) do
+ActiveRecord::Schema.define(version: 20170104115438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,8 @@ ActiveRecord::Schema.define(version: 20161225062736) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  add_index "favorites", ["user_id", "item_id"], name: "index_favorites_on_user_id_and_item_id", unique: true, using: :btree
 
   create_table "items", force: :cascade do |t|
     t.integer  "user_id",      null: false

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,6 +1,10 @@
 FactoryGirl.define do
   factory :favorite do
-    user
-    item
+    sequence :user_id do |n|
+      n
+    end
+    sequence :item_id do |n|
+      n
+    end
   end
 end

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,10 +1,6 @@
 FactoryGirl.define do
   factory :favorite do
-    sequence :user_id do |n|
-      n
-    end
-    sequence :item_id do |n|
-      n
-    end
+    user
+    item
   end
 end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,16 +1,12 @@
 require 'rails_helper'
 
 describe Favorite do
-  let(:favorite) { FactoryGirl.create(:favorite) }
-  let(:other) { FactoryGirl.build(:favorite) }
+  let(:user) { FactoryGirl.create(:user) }
 
-  # 同じアイテムを複数回お気に入りにできない
-  it "user_idとitem_idの組み合わせがユニークなのでvalid" do
-    expect(other).to be_valid
-  end
-
-  it "user_idとitem_idの組み合わせがユニークではないのでinvalid" do
-    overlap = Favorite.new(user_id: favorite.user_id, item_id: favorite.item_id)
-    expect(overlap).not_to be_valid
+  it "同じアイテムを複数回お気に入りにできない" do
+    favorite = user.favorites.build(item_id: 100)
+    expect(favorite.save).to be_truthy
+    favorite = user.favorites.build(item_id: 100)
+    expect(favorite.save).to be_falsey
   end
 end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,5 +1,16 @@
 require 'rails_helper'
 
-# RSpec.describe Favorite, type: :model do
-#   pending "add some examples to (or delete) #{__FILE__}"
-# end
+describe Favorite do
+  let(:favorite) { FactoryGirl.create(:favorite) }
+  let(:other) { FactoryGirl.build(:favorite) }
+
+  # 同じアイテムを複数回お気に入りにできない
+  it "user_idとitem_idの組み合わせがユニークなのでvalid" do
+    expect(other).to be_valid
+  end
+
+  it "user_idとitem_idの組み合わせがユニークではないのでinvalid" do
+    overlap = Favorite.new(user_id: favorite.user_id, item_id: favorite.item_id)
+    expect(overlap).not_to be_valid
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -88,4 +88,9 @@ describe 'add_fav' do
   it "自分がオーナーのアイテムはお気に入りに追加できない" do
     expect{ item.add_fav(item.user) }.to raise_error(StandardError)
   end
+
+  it "同じアイテムを複数回お気に入りにできない" do
+    expect(item.add_fav(other).item_id).to eq item.id
+    expect{ item.add_fav(other) }.to raise_error(ActiveRecord::RecordInvalid)
+  end
 end


### PR DESCRIPTION
closed #21

- [x]  Favoriteモデルへuser_idとitem_idの組み合わせがユニークとなるようなバリデーションを設定する
- [x]  Favoriteモデルで作成したバリデーションのテストをする
- [x]  favoritesテーブルにも複合ユニーク制約をを設定する