### PR TITLE
全体の見直し

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -9,7 +9,7 @@ class FavoritesController < ApplicationController
 
   def destroy
     favorite = Favorite.find(params[:id])
-    raise PermissionDeniedError, "アクセス権がありません" unless favorite.user == current_user
+    raise PermissionDeniedError, "アクセス権がありません" unless favorite.favorited_by?(current_user)
     favorite.destroy
     redirect_to favorite.item, notice: 'お気に入りから削除されました'
   end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,6 +1,6 @@
 class FavoritesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_item
+  before_action :set_item, only: :create
 
   def create
     @item.add_fav(current_user)
@@ -11,7 +11,7 @@ class FavoritesController < ApplicationController
     favorite = Favorite.find(params[:id])
     raise PermissionDeniedError, "アクセス権がありません" unless favorite.user == current_user
     favorite.destroy
-    redirect_to @item, notice: 'お気に入りから削除されました'
+    redirect_to favorite.item, notice: 'お気に入りから削除されました'
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,7 +12,7 @@ class ItemsController < ApplicationController
   # GET /items/1
   # GET /items/1.json
   def show
-    @favorite = @item.find_fav(current_user)
+    @favorite = @item.find_fav(current_user) if user_signed_in?
   end
 
   # GET /items/new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,6 +12,7 @@ class ItemsController < ApplicationController
   # GET /items/1
   # GET /items/1.json
   def show
+    @favorite = @item.find_fav(current_user)
   end
 
   # GET /items/new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,9 +29,7 @@ class ItemsController < ApplicationController
   # POST /items.json
   def create
     @item = current_user.items.build(item_params)
-    if @item.target_price
-      @item.target_price.tr!("０-９", "0-9")
-    end
+    @item.to_half_width
     respond_to do |format|
       if @item.save
         format.html { redirect_to @item, notice: 'アイテムが出品されました' }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,7 +29,6 @@ class ItemsController < ApplicationController
   # POST /items.json
   def create
     @item = current_user.items.build(item_params)
-    @item.to_half_width
     respond_to do |format|
       if @item.save
         format.html { redirect_to @item, notice: 'アイテムが出品されました' }

--- a/app/controllers/supports_controller.rb
+++ b/app/controllers/supports_controller.rb
@@ -2,6 +2,7 @@ class SupportsController < ApplicationController
   before_action :set_item
   before_action :store_event_url
   before_action :authenticate_user!
+  before_action :check_youcanbuy
 
   def buy
     current_user.supports.create!(item_id: @item.id)
@@ -16,5 +17,10 @@ private
 
   def store_event_url
     session[:user_return_to] = item_path(@item) unless user_signed_in?
+  end
+
+  # Check if the owner of the item.
+  def check_youcanbuy
+    raise PermissionDeniedError, "出品したアイテムはサポートできません" if @item.editable_by?(current_user)
   end
 end

--- a/app/controllers/supports_controller.rb
+++ b/app/controllers/supports_controller.rb
@@ -2,7 +2,7 @@ class SupportsController < ApplicationController
   before_action :set_item
   before_action :store_event_url
   before_action :authenticate_user!
-  before_action :check_youcanbuy
+  before_action :check_buyable
 
   def buy
     current_user.supports.create!(item_id: @item.id)
@@ -20,7 +20,7 @@ private
   end
 
   # Check if the owner of the item.
-  def check_youcanbuy
-    raise PermissionDeniedError, "出品したアイテムはサポートできません" if @item.editable_by?(current_user)
+  def check_buyable
+    raise PermissionDeniedError, "出品したアイテムはサポートできません" if @item.owner?(current_user)
   end
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -2,6 +2,12 @@ class Favorite < ActiveRecord::Base
   #relation
   belongs_to :user
   belongs_to :item
+  
   #validation
   validates :user_id, uniqueness: { scope: [:item_id] }
+
+  #check if you can addfav
+  def favorited_by?(user)
+    self.user_id == user.id
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -38,4 +38,9 @@ class Item < ActiveRecord::Base
   def favorited_by?(user)
     self.find_fav(user).present?
   end
+
+  #Convert full-width characters to half-width characters
+  def to_half_width
+    self.target_price.tr!("０-９", "0-9") if self.target_price
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -23,6 +23,11 @@ class Item < ActiveRecord::Base
     self.user_id == user.id
   end
 
+  #check if the owner of the item
+  def owner?(user)
+    self.user_id == user.id
+  end
+
   #add a item to your favorites
   def add_fav(user)
     raise StandardError, "このアイテムのオーナー様は、アイテムをお気に入り登録できません" if self.user_id == user.id
@@ -39,8 +44,9 @@ class Item < ActiveRecord::Base
     self.find_fav(user).present?
   end
 
-  #Convert full-width characters to half-width characters
-  def to_half_width
-    self.target_price.tr!("０-９", "0-9") if self.target_price
+  #Convert ZENKAKU to HANKAKU characters
+  def target_price=(value)
+    value.tr!('０-９', '0-9') if value.is_a?(String)
+    super(value)
   end
 end

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -6,7 +6,8 @@
       <th>商品イメージ</th>
       <th>商品について</th>
       <th>目標金額</th>
-      <th>サポーター</th>
+      <th>サポート件数</th>
+      <th>お気に入り数</th>
       <th>終了日</th>
       <th colspan="3"></th>
     </tr>
@@ -20,7 +21,8 @@
         <td><%= item.image %></td>
         <td><%= item.description %></td>
         <td><%= number_to_currency(item.target_price, :locale => 'jp') %></td>
-        <td><%= item.supports.count %>人</td>
+        <td><%= item.supports.count %>件</td>
+        <td><%= item.favorites.count %>人</td>
         <td><%= item.limited_at.strftime('%Y年%m月%d日') %></td>
         <td><%= link_to 'Show', item %></td>
         <% if user_signed_in? && item.editable_by?(current_user) %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,5 +1,5 @@
 <h1>アイテム一覧</h1>
 
-<%= render partial: "item", :locals => {items: @items} %>
+<%= render "item", items: @items %>
 <br>
 <%= link_to 'New Item', new_item_path %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -39,7 +39,7 @@
 
 <% if user_signed_in? && !@item.editable_by?(current_user) %>
   <% if @item.favorited_by?(current_user) %>
-    <p><button><%= link_to 'お気に入りから削除', favorite_path(@item.find_fav(current_user), item_id: @item.id), method: :delete %></button></p>
+    <p><button><%= link_to 'お気に入りから削除', favorite_path(@favorite), method: :delete %></button></p>
   <% else %>
     <p><button><%= link_to 'お気に入りに登録', user_favorites_path(current_user.id, item_id: @item.id), method: :post %></button></p>
   <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -33,7 +33,8 @@
   <%= @item.limited_at.strftime('%Y年%m月%d日') %>
 </p>
 
-<p><%= @item.supports.count %>人が支援しています。</p>
+<p><%= @item.supports.count %>件サポートされています。</p>
+<p><%= @item.favorites.count %>人にお気に入りされています。</p>
 
 <p><%= link_to 'このコースに申し込む', buy_path(@item), method: :post %></p>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -33,21 +33,42 @@
   <%= @item.limited_at.strftime('%Y年%m月%d日') %>
 </p>
 
-<p><%= @item.supports.count %>件サポートされています。</p>
-<p><%= @item.favorites.count %>人にお気に入りされています。</p>
-
-<p><%= link_to 'このコースに申し込む', buy_path(@item), method: :post %></p>
-
+<!-- ログイン＆一般ユーザ用リンク -->
 <% if user_signed_in? && !@item.editable_by?(current_user) %>
+  <p>
+    <button><%= link_to 'このコースに申し込む', buy_path(@item), method: :post %></button>
+    <%= @item.supports.count %>件サポートされています。
+  </p>
+
   <% if @item.favorited_by?(current_user) %>
-    <p><button><%= link_to 'お気に入りから削除', favorite_path(@favorite), method: :delete %></button></p>
+    <p>
+      <button><%= link_to 'お気に入りから削除', favorite_path(@favorite), method: :delete %></button>
+      <%= @item.favorites.count %>人にお気に入りされています。
+    </p>
   <% else %>
-    <p><button><%= link_to 'お気に入りに登録', user_favorites_path(current_user.id, item_id: @item.id), method: :post %></button></p>
+    <p>
+      <button><%= link_to 'お気に入りに登録', user_favorites_path(current_user.id, item_id: @item.id), method: :post %></button>
+      <%= @item.favorites.count %>人にお気に入りされています。
+    </p>
   <% end %>
 <% end %>
 
+<!-- ログイン＆オーナーユーザ用リンク -->
+<% if user_signed_in? && @item.editable_by?(current_user) %>
+  <p><%= @item.supports.count %>件サポートされています。</p>
+  <p><%= @item.favorites.count %>人にお気に入りされています。</p>
+<% end %>
+
+<!-- 未ログインユーザ用リンク -->
 <% unless user_signed_in? %>
-  <p><button><%= link_to 'お気に入りに登録', user_favorites_path(0, item_id: @item.id), method: :post %></button></p>
+  <p>
+    <button><%= link_to 'このコースに申し込む', buy_path(@item), method: :post %></button>
+    <%= @item.supports.count %>件サポートされています。
+  </p>
+  <p>
+    <button><%= link_to 'お気に入りに登録', user_favorites_path(0, item_id: @item.id), method: :post %></button>
+    <%= @item.favorites.count %>人にお気に入りされています。
+  </p>
 <% end %>
 
  <%= link_to 'Back', root_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   resources :users, shallow:true do
     resources :favorites,only:[:create, :destroy]
-  end  
+  end
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,0 +1,13 @@
+# favorite(お気に入り)が他人のものでないかどうかたしかめる
+describe 'favorited_by?' do
+  let(:favorite) { FactoryGirl.create(:favorite) }
+  let(:other) { FactoryGirl.create(:user) }
+
+  it "current_userのfavoriteなので、真" do
+    expect(favorite.favorited_by?(favorite.user)).to eq true
+  end
+
+  it "current_userのfavoriteではないので、偽" do
+    expect(favorite.favorited_by?(other)).to eq false
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -46,24 +46,15 @@ describe Item do
       expect(item).not_to be_valid
   end
 
-  it "target_priceが全角数字ならOK" do
+  it "target_priceが全角数字なら半角に変換される" do
     item.target_price = "１２３４５"
-      expect(item).not_to be_valid
+      expect(item.target_price).to eq "12345"
   end
 
   # limited_at(募集期間の終了日)、過去の日付は不可
   it "limited_atが過去の日付ならNG" do
     item.limited_at = Date.today-1
     expect(item).not_to be_valid
-  end
-end
-
-describe 'to_half_width' do
-  let(:item) { FactoryGirl.build(:item) }
-
-  it "target_priceが全角なら半角に変換する" do
-      item.target_price = "１２３４５"
-      expect(item.to_half_width).to eq "12345"
   end
 end
 
@@ -136,5 +127,19 @@ describe 'favorited_by?' do
 
   it "itemがお気に入りされていないので、偽" do
     expect(item.favorited_by?(other)).to eq false
+  end
+end
+
+describe 'owner?' do
+  let(:item) { FactoryGirl.create(:item) }
+  let(:other) { FactoryGirl.create(:user) }
+
+  # itemのownerかどうか真偽値で返す＊＊
+  it "userがitemのownerなので、真" do
+    expect(item.owner?(item.user)).to eq true
+  end
+
+  it "userがitemのownerではないので、偽" do
+    expect(item.owner?(other)).to eq false
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -46,10 +46,24 @@ describe Item do
       expect(item).not_to be_valid
   end
 
+  it "target_priceが全角数字ならOK" do
+    item.target_price = "１２３４５"
+      expect(item).not_to be_valid
+  end
+
   # limited_at(募集期間の終了日)、過去の日付は不可
   it "limited_atが過去の日付ならNG" do
     item.limited_at = Date.today-1
     expect(item).not_to be_valid
+  end
+end
+
+describe 'to_half_width' do
+  let(:item) { FactoryGirl.build(:item) }
+
+  it "target_priceが全角なら半角に変換する" do
+      item.target_price = "１２３４５"
+      expect(item.to_half_width).to eq "12345"
   end
 end
 


### PR DESCRIPTION
closed #24 
### 全体見直し favorite#destroyへのパス周りを修正
- [x] アイテム詳細画面のお気に入り削除ボタンのリンク内容を修正しました。

### 全体見直し favorite#favorited_by?メソッド追加
- [x] ユーザ自身のお気に入りかどうか調べる、favorite#favorited_by?メソッド追加

### 全体見直し favorite#to_half_widthメソッド追加
- [x] ターゲットプライスを全角で入力されたら自動で半角にする、メソッドを下記のように変更する。
http://qiita.com/K_Matsumoto/items/9719693d1e354812a52a

### 全体見直し サポート件数、お気に入り人数の表示を変更
- [x] お気に入り件数を表示
- [x] サポートは一人何回でもできる仕様なので、viewの表現を変更

### 全体見直し 自分のアイテムを買えないようにする
- [x] アイテムのオーナーは、自分のアイテムを買えない（サポート）ようにする
- [x] その他viewの調整