### PR TITLE
supput_courseとstatusカラムを追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -72,7 +72,9 @@ class ItemsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def item_params
-      params.require(:item).permit(:user_id, :name, :image, :image_cache, :description, :target_price, :limited_at, :category)
+      params.require(:item).permit(
+        :user_id, :name, :image, :image_cache, :description, :target_price, :limited_at, :category, :support_course
+      )
     end
 
     # Check if the owner of the item.

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -17,6 +17,10 @@ class Item < ActiveRecord::Base
     end
   end
   validates :category, presence: true
+  validates :support_course, presence: true, numericality: {
+            only_integer: true, greater_than: 0
+          }
+  validates :status, presence: true
 
   #scope
   scope :low, -> { where target_price: 1..9999 }                  # 1 〜 19,999円
@@ -29,6 +33,10 @@ class Item < ActiveRecord::Base
       return high if price == 'high'
       all # 条件に合わなければall
   }
+
+  # enum
+  enum category: { toy_game: 0, outdoors_sports: 1, workspace: 2, life_style: 3, other: 4 }
+  enum status: { available: 0, success: 1, give_up: 2 }
 
   #check if you can edit
   def editable_by?(user)
@@ -55,9 +63,6 @@ class Item < ActiveRecord::Base
   def favorited_by?(user)
     self.find_fav(user).present?
   end
-
-  # enum
-  enum category: { toy_game: 0, outdoors_sports: 1, workspace: 2, life_style: 3, other: 4 }
 
   #Convert ZENKAKU to HANKAKU characters
   def target_price=(value)

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -29,6 +29,10 @@
     <%= f.label :target_price %><br>
     <%= f.text_field :target_price, data: { autonumeric: { aSign: '¥ ', mDec: 0 } }%>
   </div>
+  <div class="field">
+    <%= f.label :support_course %><br>
+    <%= f.text_field :support_course, data: { autonumeric: { aSign: '¥ ', mDec: 0 } }%>
+  </div>
 
   <div class="field">
     <%= f.label :limited_at %><br>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -38,6 +38,11 @@
   <%= @item.category_i18n %>
 </p>
 
+<p>
+  <strong>支援コース:</strong>
+  <%= number_to_currency(@item.support_course, :locale => 'jp') %>
+</p>
+
 <!-- ログイン＆一般ユーザ用リンク -->
 <% if user_signed_in? && !@item.editable_by?(current_user) %>
   <p>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,6 +8,10 @@ ja:
         workspace: ワークスペース
         life_style: ライフスタイル
         other: その他
+      status:
+        available: 進行中
+        success: 達成
+        give_up: 不達
   activerecord:
     errors:
       messages:
@@ -26,6 +30,7 @@ ja:
         updated_at: 更新日時
         target_price: 目標金額
         category: カテゴリー
+        support_course: 支援コース額
       user:
         id: ID
         email: メールアドレス

--- a/db/migrate/20170115190142_add_support_course_to_items.rb
+++ b/db/migrate/20170115190142_add_support_course_to_items.rb
@@ -1,0 +1,5 @@
+class AddSupportCourseToItems < ActiveRecord::Migration
+  def change
+    add_column :items, :support_course, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20170115190642_add_status_to_items.rb
+++ b/db/migrate/20170115190642_add_status_to_items.rb
@@ -1,0 +1,5 @@
+class AddStatusToItems < ActiveRecord::Migration
+  def change
+    add_column :items, :status, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20170115221129_change_column_to_items.rb
+++ b/db/migrate/20170115221129_change_column_to_items.rb
@@ -1,0 +1,5 @@
+class ChangeColumnToItems < ActiveRecord::Migration
+  def change
+    change_column :items, :target_price, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170110142023) do
+ActiveRecord::Schema.define(version: 20170115221129) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,15 +26,17 @@ ActiveRecord::Schema.define(version: 20170110142023) do
   add_index "favorites", ["user_id", "item_id"], name: "index_favorites_on_user_id_and_item_id", unique: true, using: :btree
 
   create_table "items", force: :cascade do |t|
-    t.integer  "user_id",                  null: false
+    t.integer  "user_id",                    null: false
     t.string   "name"
     t.string   "image"
     t.text     "description"
-    t.integer  "target_price"
+    t.integer  "target_price",   default: 0, null: false
     t.date     "limited_at"
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
-    t.integer  "category",     default: 4, null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.integer  "category",       default: 4, null: false
+    t.integer  "support_course", default: 0, null: false
+    t.integer  "status",         default: 0, null: false
   end
 
   create_table "supports", force: :cascade do |t|

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -5,6 +5,8 @@ FactoryGirl.define do
     target_price 100
     limited_at Date.today
     category 0
+    support_course 1000
+    status 0
     user # ファクトリよびだし
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -4,7 +4,7 @@ describe Item do
   let(:item) { FactoryGirl.build(:item) }
 
   # 以下の４つの属性に対して値をセットしてvaildとなるか確認する
-  it "user_id, name, target_price, limited_at, categoryが存在すればOK" do
+  it "user_id, name, target_price, limited_at, category, retail_price, statusが存在すればOK" do
     expect(item).to be_valid
   end
 
@@ -60,6 +60,26 @@ describe Item do
   it "categoryが存在しなければNG" do
     item.category = nil
     expect(item).not_to be_valid
+  end
+
+  it "support_courseが存在しなければNG" do
+      item.support_course = nil
+      expect(item).not_to be_valid
+  end
+
+  it "support_courseがひらがなならNG" do
+    item.support_course = "あ"
+      expect(item).not_to be_valid
+  end
+
+  it "support_courseがゼロならNG" do
+    item.support_course = 0
+      expect(item).not_to be_valid
+  end
+
+  it "statusが存在しなければNG" do
+    item.status = nil
+      expect(item).not_to be_valid
   end
 end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -20,35 +20,34 @@ describe Item do
   end
 
   # target_price(目標金額)、not null、数字のみ
-
   it "target_priceが存在しなければNG" do
-      item.target_price = nil
-      expect(item).not_to be_valid
+    item.target_price = nil
+    expect(item).not_to be_valid
   end
 
   it "target_priceがアルファベットならNG" do
-      item.target_price = "A"
-      expect(item).not_to be_valid
+    item.target_price = "A"
+    expect(item).not_to be_valid
   end
 
   it "target_priceが記号ならNG" do
     item.target_price = "@"
-      expect(item).not_to be_valid
+    expect(item).not_to be_valid
   end
 
   it "target_priceがひらがなならNG" do
     item.target_price = "あ"
-      expect(item).not_to be_valid
+    expect(item).not_to be_valid
   end
 
   it "target_priceがゼロならNG" do
     item.target_price = 0
-      expect(item).not_to be_valid
+    expect(item).not_to be_valid
   end
 
   it "target_priceが全角数字なら半角に変換される" do
     item.target_price = "１２３４５"
-      expect(item.target_price).to eq 12345
+    expect(item.target_price).to eq 12345
   end
 
   # limited_at(募集期間の終了日)、過去の日付は不可
@@ -63,23 +62,23 @@ describe Item do
   end
 
   it "support_courseが存在しなければNG" do
-      item.support_course = nil
-      expect(item).not_to be_valid
+    item.support_course = nil
+    expect(item).not_to be_valid
   end
 
   it "support_courseがひらがなならNG" do
     item.support_course = "あ"
-      expect(item).not_to be_valid
+    expect(item).not_to be_valid
   end
 
   it "support_courseがゼロならNG" do
     item.support_course = 0
-      expect(item).not_to be_valid
+    expect(item).not_to be_valid
   end
 
   it "statusが存在しなければNG" do
     item.status = nil
-      expect(item).not_to be_valid
+    expect(item).not_to be_valid
   end
 end
 


### PR DESCRIPTION
closed #35 

- [x] support_course(支援コース額)カラムを追加する  (integer not_null default:0)
- [x] statusカラムを追加する (integer not_null default:0)
- [x] target_priceカラムのdefaultを`null`から`0`へ変更。（support_courseと見た目を合わせる為）
- [x] statusをenumで定義する
- [x] テストを追加・修正
- [x] アイテム詳細の画面にsupport_course（支援コース額）を表示させる